### PR TITLE
Module bundler (webpack) compatible export

### DIFF
--- a/src/languages.js
+++ b/src/languages.js
@@ -66,13 +66,14 @@
         )
     };
 
-    if (typeof window !== 'undefined') {
+    if (typeof module === 'object' && module.exports) {
+        module.exports = languages;
+    }
+    
+    else if (typeof window !== 'undefined') {
         var Tipograph = window.Tipograph || {};
         Tipograph.Languages = languages;
         window.Tipograph = Tipograph;
     }
-
-    else {
-        module.exports = languages;
-    }
+    
 })();

--- a/src/replace.js
+++ b/src/replace.js
@@ -379,14 +379,14 @@
                     
         return escapeHtml ? html.unescape(input) : input;
     };
-
-    if (typeof window !== 'undefined') {
+    
+    if (typeof module === 'object' && module.exports) {
+        module.exports = new Replace(config);
+    }
+    
+    else if (typeof window !== 'undefined') {
         var Tipograph = window.Tipograph || {};
         Tipograph.Replace = new Replace(config);
         window.Tipograph = Tipograph;
-    }
-
-    else {
-        module.exports = new Replace(config);
     }
 })();


### PR DESCRIPTION
This is needed for most module bundler that transpile the exports syntax to run on the client.
The transpiling worked correctly, but `window` isn't `undefined` on the client.
Therefore `Replace` and `Languages` were `undefined` on the client.

This fix detects if module exports exists, and exports if so.
Adding it to the window object is treated like an escape hatch.

I had the problem using webpack but I imagine other bundlers will work the same.

Cheers!

